### PR TITLE
Dynamically set localhost server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oas-generator",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oas-generator",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "OAS code generator",
   "main": "src/index.js",
   "scripts": {

--- a/src/auxiliary/index.js
+++ b/src/auxiliary/index.js
@@ -26,6 +26,26 @@ var options_object = {
 
 oasTools.configure(options_object);
 
+if (oasDoc.servers) {
+  var localServer = oasDoc.servers.find((server) => server.url.substr(0, 16) === 'http://localhost');
+  if (!localServer) {
+    console.log("No localhost server found in spec file, added for testing purposes");
+    var foundServer = oasDoc.servers[0];
+    console.log(foundServer.url.split('/').slice(3));
+    var basePath = '/' + foundServer.url.split('/').slice(3).join('/');
+    oasDoc.servers.push({
+      url: 'http://localhost:' + serverPort + basePath
+    });
+  }
+} else {
+  console.log("No servers found in spec file, added localhost server for testing purposes");
+  oasDoc.servers = [
+    {
+      url: 'http://localhost:' + serverPort
+    }
+  ]
+}
+
 oasTools.initialize(oasDoc, app, function() {
   http.createServer(app).listen(serverPort, function() {
     console.log("App running at http://localhost:" + serverPort);


### PR DESCRIPTION
If no localhost server is found in the input spec file, it will be temporarily added during runtime, using the port specified in the "serverPort" variable.